### PR TITLE
corrected link to OpenCage

### DIFF
--- a/5_Geocoding.Rmd
+++ b/5_Geocoding.Rmd
@@ -293,7 +293,7 @@ write.csv(dogs2, "dangerous_dogs2.csv", row.names=F)
 
 - [`nominatim`](https://github.com/hrbrmstr/nominatim) (not on CRAN) connects to [OSM Nominatim](http://nominatim.openstreetmap.org)
 
-- [`opencage`](https://CRAN.R-project.org/package=opencage) connects to [OpenCage geocoder](https://geocoder.opencagedata.com/) 
+- [`opencage`](https://CRAN.R-project.org/package=opencage) connects to [OpenCage geocoder](https://opencagedata.com/) 
 
 - [threewords](https://CRAN.R-project.org/package=threewords) connects to the [What3Words](http://what3words.com/) 
 


### PR DESCRIPTION
Hi, Ed from OpenCage here, one of the geocoding services you mention. Thanks for listing up, this is just minor edit to correct the URL.
Your tutorial focuses on forward geocoding (address to lat/long) but thought I should mention we have a detailed overview of reverse geocoding, please see: https://opencagedata.com/reverse-geocoding
If you think it's relevant happy to add submit a PR with a link to it in the reverse geocoding section.

thanks for your attention,
Ed